### PR TITLE
fix: 支持CPU/GPU h264/h265编码器选择

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 # 忽略整个便携式Python环境，它体积庞大且因人而异
 /python_portable/
 
+# 忽略 ffmpeg 依赖文件
+/dependencies/
+
 # 忽略由 whisper 自动下载的模型文件
 # 模型应由用户在首次运行时自动获取
 /models/

--- a/core/codec_config.py
+++ b/core/codec_config.py
@@ -1,0 +1,90 @@
+# core/codec_config.py
+"""
+视频编码器配置模块
+统一管理不同编码器的参数配置
+"""
+
+# 编码器参数配置
+CODEC_PARAMS = {
+    'h264_nvenc': {
+        'params': ['-preset', 'p5', '-cq', '18'],
+        'description': 'NVIDIA GPU H.264编码器'
+    },
+    'hevc_nvenc': {
+        'params': ['-preset', 'p4', '-cq', '20'],
+        'description': 'NVIDIA GPU H.265编码器'
+    },
+    'libx264': {
+        'params': ['-preset', 'medium', '-crf', '18'],
+        'description': 'CPU H.264编码器'
+    },
+    'libx265': {
+        'params': ['-preset', 'medium', '-crf', '20'],
+        'description': 'CPU H.265编码器'
+    },
+    'copy': {
+        'params': [],
+        'description': '无损复制（不重新编码）'
+    }
+}
+
+# 默认编码参数
+DEFAULT_CODEC_PARAMS = ['-preset', 'medium', '-crf', '18']
+
+# 编码器显示名称
+CODEC_DISPLAY_NAMES = {
+    'h264_nvenc': 'h264_nvenc (N卡)',
+    'hevc_nvenc': 'hevc_nvenc (N卡)',
+    'libx264': 'libx264 (CPU)',
+    'libx265': 'libx265 (CPU)',
+    'copy': 'copy (无损复制)'
+}
+
+# UI中的编码器选项列表
+def get_codec_options_for_ui(include_copy=False, include_h265=True, copy_label="copy (无损复制)"):
+    options = []
+    
+    if include_copy:
+        options.append(copy_label)
+    
+    options.extend([
+        "h264_nvenc (N卡)",
+        "libx264 (CPU)"
+    ])
+    
+    if include_h265:
+        options.insert(-1, "hevc_nvenc (N卡)")  # 插入到CPU前面
+        options.append("libx265 (CPU)")
+    
+    return options
+
+def get_codec_params(codec_name):
+    # 从显示名称提取实际编码器名称
+    actual_codec = codec_name
+    for codec, display_name in CODEC_DISPLAY_NAMES.items():
+        if codec in codec_name:
+            actual_codec = codec
+            break
+    
+    return CODEC_PARAMS.get(actual_codec, {}).get('params', DEFAULT_CODEC_PARAMS)
+
+def get_actual_codec_name(codec_display_name):
+    """提取实际编码器名称"""
+    for codec, display_name in CODEC_DISPLAY_NAMES.items():
+        if codec in codec_display_name:
+            return codec
+    return codec_display_name
+
+def build_video_command_with_codec(base_command, codec_name, output_file=None):
+    """构建完整的FFmpeg命令"""
+    command = base_command.copy()
+    
+    # copy模式不需要额外编码参数
+    if codec_name != 'copy':
+        codec_params = get_codec_params(codec_name)
+        command.extend(codec_params)
+    
+    if output_file:
+        command.extend(['-y', output_file])
+    
+    return command

--- a/core/workers/canvas_worker.py
+++ b/core/workers/canvas_worker.py
@@ -6,6 +6,7 @@ from PySide6.QtCore import QObject, Signal
 
 from core.utils import get_video_duration, get_video_dimensions
 from core.subtitle_converter import lrc_to_centered_canvas_ass
+from core.codec_config import build_video_command_with_codec, get_actual_codec_name
 
 class CanvasBurnWorker(QObject):
     """在后台执行竖屏视频+画布+字幕的合成任务。"""
@@ -57,15 +58,16 @@ class CanvasBurnWorker(QObject):
             sub_filter = f"subtitles='{escaped_ass_path}'"
             vf_chain = f"{pad_filter},{sub_filter}"
 
-            command = [
+            # 使用统一的编码器配置
+            codec = get_actual_codec_name(self.params['codec'])
+            base_command = [
                 '-hide_banner', '-i', video_file,
                 '-vf', vf_chain,
-                '-c:v', self.params['codec'],
-                # 【修复】强制重新编码音频以保证同步，不再使用 '-c:a', 'copy'
-                '-c:a', 'aac', '-b:a', '192k',
-                '-preset', 'p5', '-cq', '18',
-                '-y', output_file
+                '-c:v', codec,
+                '-c:a', 'aac', '-b:a', '192k'
             ]
+            
+            command = build_video_command_with_codec(base_command, codec, output_file)
             
             process = subprocess.Popen([self.ffmpeg_path] + command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, universal_newlines=True, bufsize=1, encoding='utf-8', errors='replace', creationflags=getattr(subprocess, 'CREATE_NO_WINDOW', 0))
             self.log_message.emit(f"🚀 执行命令: {' '.join(['ffmpeg'] + command)}")

--- a/ui/tabs/canvas_tab.py
+++ b/ui/tabs/canvas_tab.py
@@ -8,6 +8,7 @@ from PySide6.QtCore import QThread, Slot, Qt
 
 from core.workers.canvas_worker import CanvasBurnWorker, CanvasPreviewWorker
 from core.utils import get_video_dimensions
+from core.codec_config import get_codec_options_for_ui
 from ui.dialogs import PreviewDialog
 
 class CanvasTab(QWidget):
@@ -72,7 +73,7 @@ class CanvasTab(QWidget):
 
         # --- 编码与控制 ---
         self.codec_combo = QComboBox()
-        self.codec_combo.addItems(["h264_nvenc (N卡)", "hevc_nvenc (N卡)", "libx264 (CPU)"])
+        self.codec_combo.addItems(get_codec_options_for_ui(include_h265=True))
         self.output_format_combo = QComboBox()
         self.output_format_combo.addItems(["mp4", "mkv", "mov", "webm", "avi", "flv", "ts"])
         self.preview_button = QPushButton("生成预览图")
@@ -84,6 +85,9 @@ class CanvasTab(QWidget):
         self.log_output.setReadOnly(True)
         self.progress_bar = QProgressBar()
         self.progress_bar.setVisible(False)
+        
+        # --- 设置默认选项 ---
+        self.codec_combo.setCurrentText("h264_nvenc (N卡)")
 
     def create_layouts(self):
         main_layout = QVBoxLayout(self)

--- a/ui/tabs/clip_tab.py
+++ b/ui/tabs/clip_tab.py
@@ -9,6 +9,7 @@ from PySide6.QtWidgets import (QWidget, QVBoxLayout, QHBoxLayout, QPushButton, Q
 from PySide6.QtCore import QThread, Slot, Qt
 
 from core.workers.clip_worker import BatchClipWorker
+from core.codec_config import get_codec_options_for_ui
 from ui.dialogs import ClipDialog
 
 class ClipTab(QWidget):
@@ -48,13 +49,16 @@ class ClipTab(QWidget):
         self.clip_format_combo = QComboBox()
         self.clip_format_combo.addItems(["mp4", "mkv", "ts", "mp3", "aac", "flac", "wav"])
         self.clip_codec_combo = QComboBox()
-        self.clip_codec_combo.addItems(["copy (无损复制)", "h264_nvenc (N卡)", "libx264 (CPU)"])
+        self.clip_codec_combo.addItems(get_codec_options_for_ui(include_copy=True, include_h265=True, copy_label="copy (无损复制)"))
         
         # --- 进度和日志 ---
         self.clip_progress_label = QLabel("等待任务...")
         self.clip_log_output = QTextEdit()
         self.clip_log_output.setReadOnly(True)
         self.start_clip_button = QPushButton("开始批量裁剪")
+        
+        # --- 设置默认选项 ---
+        self.clip_codec_combo.setCurrentText("copy (无损复制)")
 
     def create_layouts(self):
         layout = QVBoxLayout(self)

--- a/ui/tabs/horizontal_tab.py
+++ b/ui/tabs/horizontal_tab.py
@@ -7,6 +7,7 @@ from PySide6.QtGui import QFont
 from PySide6.QtCore import QThread, Slot
 
 from core.workers.horizontal_worker import HorizontalBurnWorker, HorizontalPreviewWorker
+from core.codec_config import get_codec_options_for_ui
 from ui.dialogs import PreviewDialog
 
 class HorizontalTab(QWidget):
@@ -51,7 +52,8 @@ class HorizontalTab(QWidget):
         self.wrap_width_spin = QSpinBox(); self.wrap_width_spin.setRange(10, 100)
 
         # --- 编码与控制 ---
-        self.codec_combo = QComboBox(); self.codec_combo.addItems(["h264_nvenc (N卡)", "hevc_nvenc (N卡)", "libx264 (CPU)"])
+        self.codec_combo = QComboBox()
+        self.codec_combo.addItems(get_codec_options_for_ui(include_h265=True))
         self.output_format_combo = QComboBox(); self.output_format_combo.addItems(["mp4", "mkv", "mov", "webm", "avi", "flv", "ts"])
         self.preview_button = QPushButton("生成预览图")
         self.start_button = QPushButton("开始制作")
@@ -60,6 +62,9 @@ class HorizontalTab(QWidget):
         # --- 日志与进度条 ---
         self.log_output = QTextEdit(); self.log_output.setReadOnly(True)
         self.progress_bar = QProgressBar(); self.progress_bar.setVisible(False)
+        
+        # --- 设置默认选项 ---
+        self.codec_combo.setCurrentText("h264_nvenc (N卡)")
 
     def create_layouts(self):
         main_layout = QVBoxLayout(self)

--- a/ui/tabs/subtitle_tab.py
+++ b/ui/tabs/subtitle_tab.py
@@ -8,6 +8,7 @@ from PySide6.QtCore import QThread, Slot
 
 from core.workers.subtitle_worker import SubtitleBurnWorker, PreviewWorker
 from core.subtitle_converter import lrc_to_ass_chatbox_region
+from core.codec_config import get_codec_options_for_ui
 from ui.dialogs import PreviewDialog
 
 class SubtitleTab(QWidget):
@@ -70,7 +71,7 @@ class SubtitleTab(QWidget):
 
         # --- 编码器和控制按钮 ---
         self.sub_codec_combo = QComboBox()
-        self.sub_codec_combo.addItems(["h264_nvenc (N卡)", "hevc_nvenc (N卡)", "libx264 (CPU)"])
+        self.sub_codec_combo.addItems(get_codec_options_for_ui(include_h265=True))
         self.sub_output_format_combo = QComboBox()
         self.sub_output_format_combo.addItems(["mp4", "mkv", "mov", "webm", "avi", "flv", "ts"])
         self.preview_button_sub = QPushButton("生成预览图")
@@ -81,6 +82,9 @@ class SubtitleTab(QWidget):
         self.log_output_sub.setReadOnly(True)
         self.progress_bar_sub = QProgressBar()
         self.progress_bar_sub.setVisible(False)
+        
+        # --- 设置默认选项 ---
+        self.sub_codec_combo.setCurrentText("h264_nvenc (N卡)")
 
     def create_layouts(self):
         main_layout = QVBoxLayout(self)

--- a/ui/tabs/transcode_tab.py
+++ b/ui/tabs/transcode_tab.py
@@ -8,6 +8,7 @@ from PySide6.QtWidgets import (QWidget, QVBoxLayout, QHBoxLayout, QPushButton, Q
 from PySide6.QtCore import QThread, Slot, Qt
 
 from core.workers.transcode_worker import BatchTranscodeWorker
+from core.codec_config import get_codec_options_for_ui
 
 class TranscodeTab(QWidget):
     def __init__(self, main_window):
@@ -40,7 +41,7 @@ class TranscodeTab(QWidget):
             "提取 aac", "提取 mp3", "提取 flac", "提取 wav", "提取 opus"
         ])
         self.batch_codec_combo = QComboBox()
-        self.batch_codec_combo.addItems(["h264_nvenc (N卡)", "hevc_nvenc (N卡)", "libx264 (CPU)", "copy (不转码)"])
+        self.batch_codec_combo.addItems(get_codec_options_for_ui(include_copy=True, include_h265=True, copy_label="copy (不转码)"))  # 支持copy选项，标签为"不转码"
 
         # --- 进度和日志 ---
         self.batch_progress_label = QLabel("等待任务...")
@@ -50,6 +51,9 @@ class TranscodeTab(QWidget):
 
         # --- 控制按钮 ---
         self.start_batch_button = QPushButton("开始处理列表")
+        
+        # --- 设置默认选项 ---
+        self.batch_codec_combo.setCurrentText("h264_nvenc (N卡)")
 
     def create_layouts(self):
         layout = QVBoxLayout(self)

--- a/ui/tabs/vbg_tab.py
+++ b/ui/tabs/vbg_tab.py
@@ -2,10 +2,11 @@
 
 import os
 from PySide6.QtWidgets import (QWidget, QVBoxLayout, QHBoxLayout, QPushButton, QLabel, QLineEdit,
-                               QProgressBar, QComboBox, QTextEdit, QMessageBox, QGridLayout)
+                               QProgressBar, QComboBox, QTextEdit, QMessageBox, QGridLayout, QApplication)
 from PySide6.QtCore import QThread, Slot, Qt
 
 from core.workers.vbg_worker import VideoFromBgWorker
+from core.codec_config import get_codec_options_for_ui
 # 【移除】不再需要 ImageCropDialog
 # from ui.dialogs import ImageCropDialog
 
@@ -43,7 +44,7 @@ class VideoFromBgTab(QWidget):
         self.vbg_format_combo = QComboBox()
         self.vbg_format_combo.addItems(["mp4", "mkv", "mov", "flv", "ts"])
         self.vbg_codec_combo = QComboBox()
-        self.vbg_codec_combo.addItems(["h264_nvenc (N卡)", "hevc_nvenc (N卡)", "libx264 (CPU)"])
+        self.vbg_codec_combo.addItems(get_codec_options_for_ui(include_copy=False, include_h265=True))
         
         # --- 进度和日志 ---
         self.vbg_progress_bar = QProgressBar()
@@ -51,6 +52,9 @@ class VideoFromBgTab(QWidget):
         self.vbg_log_output = QTextEdit()
         self.vbg_log_output.setReadOnly(True)
         self.start_vbg_button = QPushButton("开始合成")
+        
+        # --- 设置默认选项 ---
+        self.vbg_codec_combo.setCurrentText("h264_nvenc (N卡)")
 
     def create_layouts(self):
         layout = QVBoxLayout(self)


### PR DESCRIPTION
## 问题
有三个编码器选项，但是实际上只有一套用于N卡的编码器参数

## 改动
1. 创建统一编码器配置模块 condec_config.py

- 共五种参数搭配
- 提供获取函数
- 为copy选项提供说明标签

2. 更新相关的Workers文件，包括：
- Canvas Worker
- Horizontal Worker
- Subtitle Worker
- Transcode Worker - 包括copy模式
- Clip Worker - 包括copy模式

3. 统一所有Tab页面的编码器选项
设置默认的选项，除了clip是copy，其余全部是N卡h264