### PR TITLE
fix: 修正标签页名字和按钮名字

### DIFF
--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -73,8 +73,8 @@ class MainWindow(QMainWindow):
         # 【新增】将新功能页添加到第一个位置
         self.tabs.addTab(transcribe_tab_widget, "语音转文本")
         
-        self.tabs.addTab(canvas_tab_widget, "竖屏画布字幕视频")
-        self.tabs.addTab(horizontal_tab_widget, "横屏字幕视频")
+        self.tabs.addTab(canvas_tab_widget, "横屏字幕视频")
+        self.tabs.addTab(horizontal_tab_widget, "竖屏字幕视频")
         self.tabs.addTab(subtitle_tab_widget, "Chatbox弹幕视频")
         self.tabs.addTab(merge_tab_widget, "合并媒体")
         self.tabs.addTab(transcode_tab_widget, "批量转码")

--- a/ui/tabs/subtitle_tab.py
+++ b/ui/tabs/subtitle_tab.py
@@ -34,7 +34,7 @@ class SubtitleTab(QWidget):
         self.video_file_path_sub = QLineEdit()
         self.browse_video_sub_btn = QPushButton("浏览视频...")
         self.lrc_file_path_sub = QLineEdit()
-        self.browse_lrc_sub_btn = QPushButton("浏览字幕...")
+        self.browse_lrc_sub_btn = QPushButton("浏览弹幕...")
         self.output_dir_sub = QLineEdit()
         self.output_dir_sub_browse_btn = QPushButton("浏览...")
 
@@ -90,7 +90,7 @@ class SubtitleTab(QWidget):
         input_layout.addWidget(QLabel("视频文件:"), 0, 0)
         input_layout.addWidget(self.video_file_path_sub, 0, 1)
         input_layout.addWidget(self.browse_video_sub_btn, 0, 2)
-        input_layout.addWidget(QLabel("字幕文件:"), 1, 0)
+        input_layout.addWidget(QLabel("弹幕文件:"), 1, 0)
         input_layout.addWidget(self.lrc_file_path_sub, 1, 1)
         input_layout.addWidget(self.browse_lrc_sub_btn, 1, 2)
         input_layout.addWidget(QLabel("输出文件夹:"), 2, 0)


### PR DESCRIPTION
1. 修正Chatbox弹幕页内"弹幕"文字

2. 修正主页面的两个标签页：横屏和竖屏标签对应错误的问题
仍保留原有功能的名称
```python
self.tabs.addTab(canvas_tab_widget, "横屏画布字幕视频")
self.tabs.addTab(horizontal_tab_widget, "横屏字幕视频")
```